### PR TITLE
Add API to __init__

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,9 @@ History
 0.6.1   (2020-10-15)
 ++++++++++++++++++++
 
+* Bug fix: fixed broken API definition.
 * Updated README to reflect new installation instructions.
+
 
 
 0.6.0   (2020-10-14)

--- a/precon/__init__.py
+++ b/precon/__init__.py
@@ -18,7 +18,129 @@ __all__ = [
     'uprate',
     'weights',
 ]
-__doc__ = """
 
+
+from .adjustments import jan_adjustment
+from .aggregation import aggregate, mean_aggregate, geo_mean_aggregate
+from .chaining import chain, unchain
+from .contributions import contributions, contributions_with_double_update
+from .double_update_methods import jan_adjust_weights, adjust_pre_doublelink
+from helpers import (
+    reindex_and_fill,
+    period_window_fill,
+    swap_columns,
+    reduce_cols,
+    map_headings,
+    axis_slice,
+    index_attrs_as_frame,
+)
+from imputation import (
+    impute_base_prices,
+    get_base_prices,
+    get_quality_adjusted_prices,
+)
+from index_methods import calculate_index
+from pipelines import index_calculator
+from re_reference import (
+    set_reference_period,
+    set_index_range,
+    full_index_to_in_year_indices,
+    in_year_indices_to_full_index,
+)
+from rounding import round_and_adjust
+from stat_compilers import (
+    get_index_and_growth_stats,
+    get_reference_table_stats,
+)
+from uprate import uprate
+from weights import get_weight_shares, reindex_weights_to_indices
+
+
+__doc__ = """
+============================================================
+precon: Python functions for Price Index production
+============================================================
+
+What is it?
+-----------
+
+**precon** is a Python package that provides a suite of speedy, vectorised
+functions for implementing common methods in the production of Price Indices.
+It aims to provide the high-level building blocks for building statistical
+systems at National Statistical Institutes (NSIs) and other research
+institutions concerned with creating indices. It has been developed in-house
+at the Office for National Statistics (ONS) and aims to become the standard
+library for price index production. This can only be achieved with help from
+the community, so all contributions are welcome!
+
+
+Installation
+------------
+
+.. code-block:: bash
+
+    pip install precon
+
+
+Use
+---
+
+.. code-block:: python
+
+    import precon
+
+
+API
+---
+
+Many functions in the **precon** package are designed to work with **pandas**
+DataFrames or Series that contain only one type of value, with any categorical
+or descriptive metadata contained within either the index or columns axis.
+Each component of a statistical operation or equation will usually be within
+it's own DataFrame, i.e. prices in one Frame and weights in another. When
+dealing with time series data, the functions expect one axis to contain
+only the datetime index. Where a function accepts more than one input
+DataFrame, they will need to share the same index values so that **pandas**
+can match up the components that the programmer wants to process together.
+Processing values using this matrix format approach allows the functions to
+take advantage of powerful **pandas**/**numpy**  vectorised methods.
+
+It is not always necessary that the time series period frequencies match up if
+the values in one DataFrame do not change over the given period frequency in
+another DataFrame, as the functions will resample to the smaller period
+frequency and fill forward the values.
+
+Check the docs for detailed guidance on each function and its parameters.
+
+
+Features
+--------
+
+* Calculate fixed-base price indices using common index methods.
+* Combine or aggregate lower-level indices to create higher-level indices.
+* Chain fixed-base indices together for a continuous time series.
+* Re-reference indices to start from a different time period.
+* Calculate contributions to higher-level indices from each of the component indices.
+* Impute new base prices over a time series.
+* Uprating values by index movements.
+* Rounding weight values with adjustment to ensure the sum doesn't change.
+* Stat compiler functions to quickly produce common sets of statistics.
+
+
+.. * Calculate contributions or aggregate up a hierarchy present in a **pandas**
+..    MultiIndex.
+
+
+Dependencies
+------------
+
+* `pandas <https://github.com/pandas-dev/pandas>`_
+* `NumPy <https://numpy.org/>`_
+
+
+Contributing to precon
+------------------------
+
+See CONTRIBUTING.rst
 
 """


### PR DESCRIPTION
Previous changes to __init__ resulted in the API for the precon namespace left undefined. This merge includes explicit import statements in __init__.py to define the API.