### PR TITLE
Fix bug in get_annual_max_count() in imputation.py

### DIFF
--- a/precon/imputation.py
+++ b/precon/imputation.py
@@ -184,4 +184,4 @@ def get_annual_max_count(
         ) -> int:
     """Counts values present in each year for df, returns max."""
     # TODO: Change this to work with user defined freq
-    return df.any(axis).groupby(lambda x: x.year).sum()
+    return int(df.any(axis).groupby(lambda x: x.year).sum().max())


### PR DESCRIPTION
`get_annual_max_count` was returning a Series rather than int, so added the .max() method and wrapped in int()