### PR TITLE
Improved get_base_prices function

### DIFF
--- a/precon/__init__.py
+++ b/precon/__init__.py
@@ -12,7 +12,7 @@ from precon.helpers import (
     reduce_cols,
     map_headings,
     axis_slice,
-    index_attrs_as_frame,
+    axis_vals_as_frame,
 )
 from precon.imputation import (
     impute_base_prices,

--- a/precon/_validation.py
+++ b/precon/_validation.py
@@ -1,6 +1,6 @@
 """Internal functions for argument validation."""
-
-from typing import Union
+from collections.abc import Sequence
+from typing import Union, Any, List
 
 
 def _handle_axis(axis: Union[str, int]) -> int:
@@ -16,3 +16,7 @@ def _handle_axis(axis: Union[str, int]) -> int:
         axis = axis_mapper.get(axis)
 
     return axis
+
+def _list_convert(x: Any) -> Union[Any, List[Any]]:
+    """Converts argument to list if not already a sequence."""
+    return [x] if not isinstance(x, Sequence) else x

--- a/precon/helpers.py
+++ b/precon/helpers.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
+from typing import Optional, Callable, Union
+
+import numpy as np
 import pandas as pd
+from pandas._typing import Level
 
 
 def reindex_and_fill(df, other, first='ffill', axis=0):
@@ -125,30 +129,54 @@ def _get_end_year(start_year):
     return str(int(start_year) - 1)
 
 
-def index_attrs_as_frame(df, attr=None, axis=0):
-    """
-    Returns a DataFrame of index attributes (or values if not
-    specified), the same shape as the given DataFrame.
+def axis_vals_as_frame(
+    df: pd.DataFrame,
+    axis: int = 0,
+    levels: Optional[Level] = None,
+    converter: Callable[[pd.Index], Union[pd.Index, np.ndarray]] = None,
+) -> pd.DataFrame:
+    """Broadcast axis values across the DataFrame.
 
-    # TODO: Get this working for case where axis = 0 and attr = None
-    """
-    if attr:
-        vals = getattr(df.axes[axis], attr).values
-    else:
-        vals = df.axes[axis].values
+    Pick the axis and optional MultIndex level. Optionally
+    transform the index object before broadcasting.
 
-    # Create an axis slice so attrs can be cast to any axis
+    Parameters
+    ----------
+    df: DataFrame
+    axis: {0, 1}, int default 0
+        The axis values to broadcast: {0:'index', 1:'columns'}.
+    levels: int or str
+        Either the integer position or the name of the level.
+    converter: callable
+        A function to transform an index object.
+
+    Returns
+    -------
+    DataFrame
+        The broadcast axis values with optional transformation.
+    """
+    vals = {0: df.index, 1: df.columns}.get(axis)
+
+    if levels:
+        vals = vals.get_level_values(levels)
+
+    if converter:
+        vals = converter(vals)
+
+    # Prepare the values to pass to np.tile which reshapes to the df.
+    if not isinstance(vals, np.ndarray):
+        vals = vals.values
+    reps = (df.shape[axis ^ 1], 1)
+
     if axis == 0:
-        slice_ = axis_slice(None, flip(axis))
-        vals = vals[slice_]
+        # Reshape vals to a column and reverse reps if axis is 0.
+        vals = vals[:, None]
+        reps = reps[::-1]
 
-    # Create an empty DataFrame in original shape for casting
-    all_attrs = pd.DataFrame().reindex_like(df)
+    df_out = df.copy()
+    df_out.loc[:, :] = np.tile(vals, reps)
 
-    all_attrs.loc[:, :] = vals
-
-    # Return with the original attribute dtype
-    return all_attrs.astype(vals.dtype)
+    return df_out
 
 
 def reduce_to_only_differing_periods(df, axis):

--- a/precon/imputation.py
+++ b/precon/imputation.py
@@ -4,14 +4,14 @@ A set of functions for imputation methods.
 # TODO: Modify the functions to work with a user defined period.
     * Look at using pd.Grouper with freq argument
 """
-from typing import Optional
+from typing import Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
 
-from precon._validation import _handle_axis
+from precon._validation import _handle_axis, _list_convert
 from precon.index_methods import calculate_index
-from precon.helpers import flip, axis_slice
+from precon.helpers import flip, axis_vals_as_frame
 from precon.weights import reindex_weights_to_indices
 
 
@@ -142,28 +142,67 @@ def impute_base_prices(
 
 def get_base_prices(
         prices: pd.DataFrame,
-        base_period: int = 1,
+        base_period: Union[int, Sequence[int]] = 1,
         axis: pd._typing.Axis = 0,
         ffill: bool = True,
+        shift: bool = True,
         ) -> pd.DataFrame:
-    """Returns the prices at the base month in the same shape as prices.
+    """Return prices at base month with optional ffill and shift.
 
-    Default behaviour is to fill forward values, but can be changed to
-    return NaN where not base_month by setting ffill=False.
+    Default behaviour is to fill forward values within the year and
+    shift one period, since base prices usually start being used in
+    the following period up to the next base period. Will return
+    NaNs in non-base month if ffill=False.
+
+    Parameters
+    ----------
+    prices : DataFrame
+    base_period : int, or list of ints
+        The base periods to select base prices from.
+    axis : {0, 1} int, defaults to 0
+        Fill and shift direction.
+    ffill : bool, defaults to True
+        Switch to forward fill values within the year.
+    shift : bool, defaults to True
+        Switch to shift values by one period.
+
+    Returns
+    -------
+    DataFrame
+        The base prices.
+
+    Notes
+    -----
+    The base prices are forward filled within each year so that base
+    prices are not filled when prices have stopped being collected.
+    When shifting, base prices are shifted by one period. So for a base
+    period of Jan (int=1) base prices are shifted on to the Feb-Jan+1
+    time delta in which they apply. A base price is needed for the Jan
+    period at the start of the series, so the function fills the
+    shifted values with the unshifted values to achieve this
+    
+    TODO: Make this work for any base period.
+    
     """
-    # TODO: Change this to work with user defined freq
-    bases = prices.axes[axis].month == base_period
-
-    # Fill all except base months with NA
-    base_prices = prices.copy()
-
-    slice_ = axis_slice(~bases, axis)
-    base_prices.iloc[slice_] = np.nan
+    base_period = _list_convert(base_period)
+    
+    # Only prices in the base periods are not NaN.
+    months = axis_vals_as_frame(prices, axis, converter=lambda x: x.month)
+    base_prices = prices.where(months.eq(base_period))
 
     if ffill:
-        return base_prices.ffill(axis)
-    else:
-        return base_prices
+        # Fill base prices forward within the year
+        base_prices = (
+            base_prices
+            .groupby(lambda x: x.year, axis=axis)
+            .fillna(method='ffill')
+        )
+        
+    if shift:
+        # Fill NAs in first period with unshifted base prices.
+        base_prices = base_prices.shift(1, axis=axis).fillna(base_prices)
+    
+    return base_prices
 
 
 def get_quality_adjusted_prices(

--- a/precon/pipelines.py
+++ b/precon/pipelines.py
@@ -74,10 +74,7 @@ def index_calculator(
             adjustments=adjustments,
         )
     else:
-        base_prices = get_base_prices(prices, base_period, axis, ffill=True)
-        # Shift is necessary because the price in the following base
-        # period uses the previous base period to calculate the index.
-        base_prices = base_prices.shift(1, axis=axis).fillna(base_prices)
+        base_prices = get_base_prices(prices, base_period, axis)
 
     return calculate_index(
         prices,

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,0 +1,161 @@
+"""A set of unit tests for the helper functions."""
+import pandas as pd
+from pandas._testing import assert_frame_equal
+import pytest
+
+from precon.helpers import axis_vals_as_frame
+from test.conftest import create_dataframe
+
+
+class TestAxisValsAsFrame:
+    """Tests for the axis_vals_as_frame function.
+
+    Uses one input dataset to test the following test cases, when:
+
+    * axis = 1
+    * axis = 0
+    * axis = 1 and converter = lambda x: x.month
+    * axis = 0, levels = 1 and conveter = lambda x: x.str.upper()
+    """
+
+    @pytest.fixture
+    def input_data(self):
+        """Return the input data for axis_vals_as_frame."""
+        df = create_dataframe(
+            [   # A and B cols are set to the index
+                ('A', 'B', '2017-01-01', '2017-02-01', '2017-03-01', '2017-04-01'),
+                (0, 'foo', None, None, None, None),
+                (1, 'bar', None, None, None, None),
+                (2, 'baz', None, None, None, None),
+                (3, 'qux', None, None, None, None),
+            ],
+        )
+        df = df.set_index(['A', 'B'])
+        df.columns = pd.to_datetime(df.columns)
+        return df
+
+    @pytest.fixture
+    def expout_column_values(self):
+        """Return the exp output for axis = 1 case."""
+        df = create_dataframe(
+            [   # A and B cols are set to the index
+                ('A', 'B', '2017-01-01', '2017-02-01', '2017-03-01', '2017-04-01'),
+                (0, 'foo', '2017-01-01', '2017-02-01', '2017-03-01', '2017-04-01'),
+                (1, 'bar', '2017-01-01', '2017-02-01', '2017-03-01', '2017-04-01'),
+                (2, 'baz', '2017-01-01', '2017-02-01', '2017-03-01', '2017-04-01'),
+                (3, 'qux', '2017-01-01', '2017-02-01', '2017-03-01', '2017-04-01'),
+            ],
+        )
+        df = df.set_index(['A', 'B'])
+        df.columns = pd.to_datetime(df.columns)
+        # Convert all the df values to datetime
+        return df.apply(pd.to_datetime)
+
+    def test_that_col_values_broadcast_across_all_rows_in_df(
+        self,
+        input_data,
+        expout_column_values,
+    ):
+        """Unit test for axis = 1 case."""
+        # GIVEN a DataFrame and axis argument = 1 for columns
+        # WHEN axis_vals_as_frame function returns
+        # THEN returns a DataFrame with the column values broadcast across each row.
+        true_output = axis_vals_as_frame(input_data, axis=1)
+
+        assert_frame_equal(true_output, expout_column_values)
+
+    @pytest.fixture
+    def expout_index_values(self):
+        """Return the exp output for axis = 0 case."""
+        df = create_dataframe(
+            [   # A and B cols are set to the index
+                ('A', 'B', '2017-01-01', '2017-02-01', '2017-03-01', '2017-04-01'),
+                (0, 'foo', (0, 'foo'), (0, 'foo'), (0, 'foo'), (0, 'foo')),
+                (1, 'bar', (1, 'bar'), (1, 'bar'), (1, 'bar'), (1, 'bar')),
+                (2, 'baz', (2, 'baz'), (2, 'baz'), (2, 'baz'), (2, 'baz')),
+                (3, 'qux', (3, 'qux'), (3, 'qux'), (3, 'qux'), (3, 'qux')),
+            ],
+        )
+        df = df.set_index(['A', 'B'])
+        df.columns = pd.to_datetime(df.columns)
+        return df
+
+    def test_that_index_values_broadcast_across_all_columns_in_df(
+        self,
+        input_data,
+        expout_index_values,
+    ):
+        """Unit test for axis = 0 case."""
+        # GIVEN a DataFrame and axis argument = 0 for index
+        # WHEN axis_vals_as_frame function returns
+        # THEN returns a DataFrame with the index values broadcast across each col.
+        true_output = axis_vals_as_frame(input_data, axis=0)
+
+        assert_frame_equal(true_output, expout_index_values)
+
+    @pytest.fixture
+    def expout_months_from_cols(self):
+        """Return exp output for axis=1 and converter=lambda x: x.month case."""
+        df = create_dataframe(
+            [   # A and B cols are set to the index
+                ('A', 'B', '2017-01-01', '2017-02-01', '2017-03-01', '2017-04-01'),
+                (0, 'foo', 1, 2, 3, 4),
+                (1, 'bar', 1, 2, 3, 4),
+                (2, 'baz', 1, 2, 3, 4),
+                (3, 'qux', 1, 2, 3, 4),
+            ],
+        )
+        df = df.set_index(['A', 'B'])
+        df.columns = pd.to_datetime(df.columns)
+        return df
+
+    def test_that_broadcasts_col_vals_across_rows_with_converter(
+        self,
+        input_data,
+        expout_months_from_cols,
+    ):
+        """Unit test for axis=1 and converter=lambda x: x.month case."""
+        # GIVEN a DataFrame, axis = 1 argument and a lambda function to get the months attr
+        # WHEN axis_vals_as_frame function returns
+        # THEN returns a DataFrame with the months broadcast across each row.
+        true_output = axis_vals_as_frame(
+            input_data,
+            axis=1,
+            converter=lambda x: x.month,
+        )
+
+        assert_frame_equal(true_output, expout_months_from_cols)
+
+    @pytest.fixture
+    def expout_index_level_1_all_caps(self):
+        """Return exp output for axis=0, levels=1 and converter = lambda x: x.upper() case."""
+        df = create_dataframe(
+            [   # A and B cols are set to the index
+                ('A', 'B', '2017-01-01', '2017-02-01', '2017-03-01', '2017-04-01'),
+                (0, 'foo', 'FOO', 'FOO', 'FOO', 'FOO'),
+                (1, 'bar', 'BAR', 'BAR', 'BAR', 'BAR'),
+                (2, 'baz', 'BAZ', 'BAZ', 'BAZ', 'BAZ'),
+                (3, 'qux', 'QUX', 'QUX', 'QUX', 'QUX'),
+            ],
+        )
+        df = df.set_index(['A', 'B'])
+        df.columns = pd.to_datetime(df.columns)
+        return df
+
+    def test_that_broadcasts_index_level_1_vals_to_columns_with_converter(
+        self,
+        input_data,
+        expout_index_level_1_all_caps,
+    ):
+        """Unit test for axis=0, levels=1 and converter = lambda x: x.upper() case."""
+        # GIVEN a DataFrame, axis=0, levels=1 and converter=lambda x: x.upper() as args
+        # WHEN axis_vals_as_frame function returns
+        # THEN returns a DataFrame with level 1 in all caps broadcast across each col.
+        true_output = axis_vals_as_frame(
+            input_data,
+            axis=0,
+            levels=1,
+            converter=lambda x: x.str.upper(),
+        )
+
+        assert_frame_equal(true_output, expout_index_level_1_all_caps)


### PR DESCRIPTION
Added functionality to ffill within year, rather than just ffill. Also added shifting forward one period as default behaviour. Finally, used the `axis_vals_as_frame` function to get the base prices, which has been improved with this commit and tests added.

Closes #24 