### PR TITLE
I28/revisit index calculator

### DIFF
--- a/precon/__init__.py
+++ b/precon/__init__.py
@@ -10,8 +10,8 @@ from precon.base_prices import (
     impute_base_prices,
     get_base_prices,
     get_quality_adjusted_prices,
-    base_price_fill_shift,
-    
+    ffill_shift,
+
 )
 from precon.chaining import chain, unchain
 from precon.contributions import contributions, contributions_with_double_update

--- a/precon/base_prices.py
+++ b/precon/base_prices.py
@@ -160,7 +160,7 @@ def impute_base_prices(
 
 def get_base_prices(
     prices: pd.DataFrame,
-    base_period: Optional[Union[int, Sequence[int]]] = 1,
+    base_period: Union[int, Sequence[int]] = 1,
     axis: pd._typing.Axis = 0,
     fill_shift: bool = True,
 ) -> pd.DataFrame:
@@ -170,11 +170,11 @@ def get_base_prices(
     ----------
     prices : DataFrame
     base_period : int, or list of ints, defaults to 1
-        The base periods to select base prices from.
+        Base period/s to select base prices from.
     axis : {0, 1} int, defaults to 0
         Fill and shift direction.
-    fill_shift: bool, defaults to True
-        Swithc to forward fill base prices within year and shift one
+    fill_shift : bool, defaults to True
+        Switch to forward fill base prices within year and shift one
         period.
 
     Returns

--- a/precon/pipelines.py
+++ b/precon/pipelines.py
@@ -1,5 +1,5 @@
 """A set of common pipeline functions to create National Statistics."""
-from typing import Optional
+from typing import Optional, Union, Sequence
 
 import pandas as pd
 from pandas._typing import Axis
@@ -15,44 +15,43 @@ from precon.helpers import flip
 
 
 def index_calculator(
-        prices: pd.DataFrame,
-        index_method: str,
-        shift_imputed_values: bool = False,
-        to_impute: Optional[pd.DataFrame] = None,
-        weights: Optional[pd.DataFrame] = None,
-        adjustments: Optional[pd.DataFrame] = None,
-        exclusions: Optional[pd.DataFrame] = None,
-        base_prices: Optional[pd.DataFrame] = None,
-        base_period: int = 1,
-        axis: Axis = 1,
-        ) -> pd.Series:
+    prices: pd.DataFrame,
+    index_method: str,
+    shift_imputed_values: bool = False,
+    to_impute: Optional[pd.DataFrame] = None,
+    weights: Optional[pd.DataFrame] = None,
+    adjustments: Optional[pd.DataFrame] = None,
+    exclusions: Optional[pd.DataFrame] = None,
+    base_prices: Optional[pd.DataFrame] = None,
+    base_period: Union[int, Sequence[int]] = 1,
+    axis: Axis = 1,
+) -> pd.Series:
     """Calculates an index given prices and an index method, with
     optional arguments for base price imputation.
 
     Parameters
     ----------
-    prices: DataFrame
+    prices : DataFrame
         The prices with which to calculate the index.
-    method: {'jevons', 'dutot', 'carli', 'laspeyres', 'geometric_laspeyres'}
+    method : {'jevons', 'dutot', 'carli', 'laspeyres', 'geometric_laspeyres'}
         Method to calculate the index.
     shift_imputed_values: bool, defaults to True
         True if imputed values are shifted onto the following period.
-    to_impute: DataFrame, optional
+    to_impute : DataFrame, optional
         A boolean mask of where to impute.
-    weights: DataFrame, optional
+    weights : DataFrame, optional
         The weights to use if the index method requires it.
-    adjustments: DataFrame, optional
-        Adjustment values to apply to prices for quality adjustment. If
-        there is no adjustment for a price then the adjustment value
-        should be zero.
-    exclusions: DataFrame, optional
+    adjustments : DataFrame, optional
+        Adjustment factors to multiply by base prices for quality
+        adjustments. A factor of 1 means no adjustment takes place.
+    exclusions : DataFrame, optional
         A boolean mask of prices to exclude from the final index
         calculation.
-    base_prices: DataFrame, optional
+    base_prices : DataFrame, optional
         Base prices to be forward filled and shifted before used in
         index calculation.
-    base_period: int, defaults to 1
-        Base period to select initial base prices from.
+    base_period : int, or list of ints, defaults to 1
+        Base period/s to select initial base prices from.
     axis : {0 or 'index', 1 or 'columns'}, defaults to 0
         The axis that holds the time series values.
 
@@ -60,6 +59,7 @@ def index_calculator(
     -------
     Series
         The index.
+
     """
     axis = _handle_axis(axis)
 
@@ -68,8 +68,7 @@ def index_calculator(
         # the final index calculation
         weights = weights.mask(exclusions, 0)
 
-    # Impute the base prices if necessary, if not just take the prices
-    # in the base period and fill forward
+    # Impute the base prices if necessary.
     if to_impute is not None:
         base_prices = impute_base_prices(
             prices,
@@ -81,10 +80,15 @@ def index_calculator(
             weights=weights,
             adjustments=adjustments,
         )
-    elif base_prices is not None:
-        base_prices = ffill_shift(base_prices, axis)
     else:
-        base_prices = get_base_prices(prices, base_period, axis)
+        if base_prices is not None:
+            base_prices = ffill_shift(base_prices, axis)
+        else:
+            # Get base prices from prices.
+            base_prices = get_base_prices(prices, base_period, axis)
+
+        if adjustments is not None:
+            base_prices *= adjustments
 
     return calculate_index(
         prices,

--- a/precon/pipelines.py
+++ b/precon/pipelines.py
@@ -5,7 +5,11 @@ import pandas as pd
 from pandas._typing import Axis
 
 from precon._validation import _handle_axis
-from precon.base_prices import impute_base_prices, get_base_prices
+from precon.base_prices import (
+    impute_base_prices,
+    get_base_prices,
+    ffill_shift,
+)
 from precon.index_methods import calculate_index
 from precon.helpers import flip
 
@@ -18,6 +22,7 @@ def index_calculator(
         weights: Optional[pd.DataFrame] = None,
         adjustments: Optional[pd.DataFrame] = None,
         exclusions: Optional[pd.DataFrame] = None,
+        base_prices: Optional[pd.DataFrame] = None,
         base_period: int = 1,
         axis: Axis = 1,
         ) -> pd.Series:
@@ -43,6 +48,9 @@ def index_calculator(
     exclusions: DataFrame, optional
         A boolean mask of prices to exclude from the final index
         calculation.
+    base_prices: DataFrame, optional
+        Base prices to be forward filled and shifted before used in
+        index calculation.
     base_period: int, defaults to 1
         Base period to select initial base prices from.
     axis : {0 or 'index', 1 or 'columns'}, defaults to 0
@@ -73,6 +81,8 @@ def index_calculator(
             weights=weights,
             adjustments=adjustments,
         )
+    elif base_prices is not None:
+        base_prices = ffill_shift(base_prices, axis)
     else:
         base_prices = get_base_prices(prices, base_period, axis)
 


### PR DESCRIPTION
- Changed `base_price_ffill_shift` to just `ffill_shift`
- Added quality adjustment to `index_calculator`
- Modified `index_calculator` so that it now accepts `base_prices` as a parameter, and fills and shifts them when it does.

Tidied some comments, type hinting and docstrings.

Closes #28 and closes #31 